### PR TITLE
Fix for specifying geometry field using attribute geo_field_name

### DIFF
--- a/wms/layers.py
+++ b/wms/layers.py
@@ -69,7 +69,7 @@ class WmsBaseLayer(object):
         """
         # If name is specified, use it, otherwise loop through candidates
         if self.geo_field_name:
-            return self.model._meta.get_field_by_name(self.geo_field_name)
+            return self.model._meta.get_field_by_name(self.geo_field_name)[0]
         else:
             for field in self.model._meta.concrete_fields:
                 if any([issubclass(field.__class__, geofield)


### PR DESCRIPTION
Thanks for this nice project!
Setting the geometry field of a layer using its name does not seem to work since Django's MyModel._meta.get_field_by_name(name) is returning a tuple and not a field (https://docs.djangoproject.com/en/1.9/ref/models/meta). I created a small pull request for fixing this issue.
Cheers, Mario